### PR TITLE
add preauthentication function

### DIFF
--- a/internal/wpa_dbus/wpa_network.go
+++ b/internal/wpa_dbus/wpa_network.go
@@ -65,3 +65,14 @@ func (self *NetworkWPA) RemoveSignalsObserver() *NetworkWPA {
 	}
 	return self
 }
+
+func (self *NetworkWPA) Remove() *NetworkWPA {
+	log.Log.Debug("Remove")
+	if self.Error == nil {
+		if call := self.Interface.Object.Call("fi.w1.wpa_supplicant1.Interface.RemoveNetwork", 0, self.Object.Path()); call.Err == nil {
+		} else {
+			self.Error = call.Err
+		}
+	}
+	return self
+}


### PR DESCRIPTION
## Details

specific platform feature: add ability to preauthenticate given ssid authentication detail

## Breakdown
- [x] add current network information getter
- [x] expose wpa_supplicant network remove function
- [x] set network removal to optional in `connectBss()` call to provide functionality for preauthenticate
- [x] connect to previous connection on pre-auth success
- [x] connect to previous connection on pre-auth fail    
- [x] expose function to get current connected network information